### PR TITLE
.NET8 and ModelUrls Type Conversion Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dev_*
 *.tss
 .vs
 project.lock.json
+src/TestResults

--- a/build.ps1
+++ b/build.ps1
@@ -18,6 +18,7 @@ Task Build -depends Clean {
     Set-Location "$solution_dir"
     Write-Host "Creating BuildArtifacts" -ForegroundColor Green
     Exec { dotnet restore }
+    Exec { dotnet test }
     Exec { dotnet pack --configuration Release --output $build_artifacts_dir } 
 }
 

--- a/src/Common.props
+++ b/src/Common.props
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+		<LangVersion>12</LangVersion>
+	</PropertyGroup>
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+	</PropertyGroup>
+	<PropertyGroup>
+		<Authors>Adam Schroder</Authors>
+		<PackageVersion>$(Version)</PackageVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<InternalsVisibleTo Include="SchoStack.AspNetCore.Tests"/>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+	</ItemGroup>
+</Project>

--- a/src/SchoStack.AspNetCore.FluentValidation/SchoStack.AspNetCore.FluentValidation.csproj
+++ b/src/SchoStack.AspNetCore.FluentValidation/SchoStack.AspNetCore.FluentValidation.csproj
@@ -1,34 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
-    <OutputType>Library</OutputType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <Company />
-    <Authors>Adam Schroder</Authors>
-    <PackageVersion>1.0.0</PackageVersion>
-    <Version>1.0.0</Version>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.3.0" />
-    <PackageReference Include="htmltags.aspnetcore" Version="7.0.4" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\SchoStack.AspNetCore.HtmlConventions\SchoStack.AspNetCore.HtmlConventions.csproj" />
-  </ItemGroup>
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="..\Common.props" />
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<Version>1.0.1</Version>
+	</PropertyGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentValidation.AspNetCore" Version="9.3.0" />
+		<PackageReference Include="HtmlTags" Version="8.1.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\SchoStack.AspNetCore.HtmlConventions\SchoStack.AspNetCore.HtmlConventions.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/SchoStack.AspNetCore.HtmlConventions/SchoStack.AspNetCore.HtmlConventions.csproj
+++ b/src/SchoStack.AspNetCore.HtmlConventions/SchoStack.AspNetCore.HtmlConventions.csproj
@@ -1,32 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
-    <OutputType>Library</OutputType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <Company />
-    <Authors>Adam Schroder</Authors>
-    <Version>1.0.1</Version>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="HtmlTags.AspNetCore" Version="7.0.4" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\SchoStack.AspNetCore.ModelUrls\SchoStack.AspNetCore.ModelUrls.csproj" />
-  </ItemGroup>
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="..\Common.props" />
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<Version>1.0.2</Version>
+	</PropertyGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="HtmlTags" Version="8.1.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\SchoStack.AspNetCore.ModelUrls\SchoStack.AspNetCore.ModelUrls.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/SchoStack.AspNetCore.Invoker/SchoStack.AspNetCore.Invoker.csproj
+++ b/src/SchoStack.AspNetCore.Invoker/SchoStack.AspNetCore.Invoker.csproj
@@ -1,23 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
-    <OutputType>Library</OutputType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <Company />
-    <Authors>Adam Schroder</Authors>
-    <PackageVersion>1.0.0</PackageVersion>
-    <Version>1.0.0</Version>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-  </ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="..\Common.props" />
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<Version>1.0.1</Version>
+	</PropertyGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
 </Project>

--- a/src/SchoStack.AspNetCore.MediatR/SchoStack.AspNetCore.MediatR.csproj
+++ b/src/SchoStack.AspNetCore.MediatR/SchoStack.AspNetCore.MediatR.csproj
@@ -1,28 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
-    <OutputType>Library</OutputType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <Company />
-    <Authors>Adam Schroder</Authors>
-    <Version>1.1.3</Version>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="MediatR" Version="10.0.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-  </ItemGroup>
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="..\Common.props" />
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<Version>1.1.4</Version>
+	</PropertyGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="MediatR" Version="10.0.1" />
+	</ItemGroup>
 </Project>

--- a/src/SchoStack.AspNetCore.ModelUrls/ActionConventionOptions.cs
+++ b/src/SchoStack.AspNetCore.ModelUrls/ActionConventionOptions.cs
@@ -4,11 +4,13 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace SchoStack.AspNetCore.ModelUrls
 {
+    public delegate string TypeFormatterDelegate(object value, ActionContext context);
+
     public class ActionConventionOptions
     {
-        public Dictionary<Type, Func<object, ActionContext, string>> TypeFormatters { get; set; } = new Dictionary<Type, Func<object, ActionContext, string>>();
+        public Dictionary<Type, TypeFormatterDelegate> TypeFormatters { get; set; } = new();
         public DefaultPropertyNameModfier PropertyNameModifier { get; set; } = new DefaultPropertyNameModfier();
-        public void AddTypeFormatter<T>(Func<object, ActionContext, string> formatter)
+        public void AddTypeFormatter<T>(TypeFormatterDelegate formatter)
         {
             TypeFormatters.Add(typeof(T), formatter);
         }

--- a/src/SchoStack.AspNetCore.ModelUrls/SchoStack.AspNetCore.ModelUrls.csproj
+++ b/src/SchoStack.AspNetCore.ModelUrls/SchoStack.AspNetCore.ModelUrls.csproj
@@ -1,29 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
-    <OutputType>Library</OutputType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <Company />
-    <Authors>Adam Schroder</Authors>
-    <PackageVersion>1.0.0</PackageVersion>
-    <Version>1.0.0</Version>
-    <IsPackable>true</IsPackable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-  </ItemGroup>
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<Import Project="..\Common.props" />
+	<PropertyGroup>
+		<OutputType>Library</OutputType>
+		<Version>1.1.0</Version>
+	</PropertyGroup>
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+	</ItemGroup>
 </Project>

--- a/src/SchoStack.AspNetCore.ModelUrls/TagHelpers.cs
+++ b/src/SchoStack.AspNetCore.ModelUrls/TagHelpers.cs
@@ -16,6 +16,8 @@ namespace SchoStack.AspNetCore.ModelUrls
     [HtmlTargetElement(Attributes = "model-url-*")]
     public class ModelUrlTagHelper : TagHelper
     {
+        public const string SchoStackModelTypeHttpContextItemKey = "SchoStack.Model";
+
         private readonly IHtmlGenerator _generator;
         private IDictionary<string, object> _modelUrls;
 
@@ -46,7 +48,7 @@ namespace SchoStack.AspNetCore.ModelUrls
             if (context.TagName == "form" && ModelUrls.ContainsKey("action"))
             {
                 var modelType = ModelUrls["action"].GetType();
-                ViewContext.HttpContext.Items["SchoStack.Model"] = modelType;
+                ViewContext.HttpContext.Items[SchoStackModelTypeHttpContextItemKey] = modelType;
                 var modelConventions = ViewContext.HttpContext.RequestServices.GetRequiredService<TypedRoutingApplicationModelConvention>();
                 if (modelConventions.RouteInformations.ContainsKey(modelType) && modelConventions.RouteInformations[modelType].Method == HttpMethod.Post)
                 {

--- a/src/SchoStack.AspNetCore.ModelUrls/UrlExtensions.cs
+++ b/src/SchoStack.AspNetCore.ModelUrls/UrlExtensions.cs
@@ -37,9 +37,9 @@ namespace SchoStack.AspNetCore.ModelUrls
         {
             await BindModelFor(urlHelper, model, bindExistingQueryString, modifiers);
 
-            var dictGenerator = new RouteValueDictionaryGenerator();
             var actionConventions = urlHelper.ActionContext.HttpContext.RequestServices.GetRequiredService<ActionConventionOptions>();
-            var dict = dictGenerator.Generate(model, (t, o) => actionConventions.TypeFormatters.ContainsKey(t) ? actionConventions.TypeFormatters[t](o, urlHelper.ActionContext) : o, (propertyInfo, atts) => actionConventions.PropertyNameModifier.GetModifiedPropertyName(propertyInfo, atts));
+            var dictGenerator = new RouteValueDictionaryGenerator(urlHelper.ActionContext, actionConventions);
+            var dict = dictGenerator.Generate(model);
             
             // Workaround for https://github.com/dotnet/aspnetcore/issues/14877
             var dict2 = dict.Concat(urlHelper.ActionContext.RouteData.Values

--- a/src/SchoStack.AspNetCore.Sample/Controllers/HomeController.cs
+++ b/src/SchoStack.AspNetCore.Sample/Controllers/HomeController.cs
@@ -1,27 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using FluentValidation;
+using FluentValidation.Results;
+using FluentValidation.Validators;
 using MediatR;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
-using SchoStack.AspNetCore.Invoker;
-using SchoStack.AspNetCore.ModelUrls;
-using SchoStack.AspNetCore.Sample.Models;
-using SchoStack.AspNetCore.MediatR;
-using SchoStack.AspNetCore.HtmlConventions;
-using SchoStack.AspNetCore.Sample.Components;
-using System.Threading;
-using FluentValidation;
-using FluentValidation.Results;
-using FluentValidation.Validators;
-using HtmlTags.Reflection;
 using SchoStack.AspNetCore.FluentValidation;
+using SchoStack.AspNetCore.HtmlConventions;
 using SchoStack.AspNetCore.HtmlConventions.Core;
+using SchoStack.AspNetCore.Invoker;
+using SchoStack.AspNetCore.MediatR;
+using SchoStack.AspNetCore.ModelUrls;
+using SchoStack.AspNetCore.Sample.Components;
+using SchoStack.AspNetCore.Sample.Models;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SchoStack.AspNetCore.Sample.Controllers
 {
@@ -98,7 +94,7 @@ namespace SchoStack.AspNetCore.Sample.Controllers
             .For(input)
             .BeforeSend(async (_, c) =>
             {
-                c.ActionContext.HttpContext.Response.Headers.Add("X-Test", "test"); 
+                c.ActionContext.HttpContext.Response.Headers["X-Test"] = "test"; 
                 await Task.CompletedTask;
             })
             .Error(async () => await About(new AboutQueryModel()))

--- a/src/SchoStack.AspNetCore.Sample/SchoStack.AspNetCore.Sample.csproj
+++ b/src/SchoStack.AspNetCore.Sample/SchoStack.AspNetCore.Sample.csproj
@@ -1,31 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="StructureMap.AspNetCore" Version="2.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\SchoStack.AspNetCore.FluentValidation\SchoStack.AspNetCore.FluentValidation.csproj" />
-    <ProjectReference Include="..\SchoStack.AspNetCore.HtmlConventions\SchoStack.AspNetCore.HtmlConventions.csproj" />
-    <ProjectReference Include="..\SchoStack.AspNetCore.Invoker\SchoStack.AspNetCore.Invoker.csproj" />
-    <ProjectReference Include="..\SchoStack.AspNetCore.MediatR\SchoStack.AspNetCore.MediatR.csproj" />
-    <ProjectReference Include="..\SchoStack.AspNetCore.ModelUrls\SchoStack.AspNetCore.ModelUrls.csproj" />
-  </ItemGroup>
-
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>12</LangVersion>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="StructureMap.AspNetCore" Version="2.0.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\SchoStack.AspNetCore.FluentValidation\SchoStack.AspNetCore.FluentValidation.csproj" />
+		<ProjectReference Include="..\SchoStack.AspNetCore.HtmlConventions\SchoStack.AspNetCore.HtmlConventions.csproj" />
+		<ProjectReference Include="..\SchoStack.AspNetCore.Invoker\SchoStack.AspNetCore.Invoker.csproj" />
+		<ProjectReference Include="..\SchoStack.AspNetCore.MediatR\SchoStack.AspNetCore.MediatR.csproj" />
+		<ProjectReference Include="..\SchoStack.AspNetCore.ModelUrls\SchoStack.AspNetCore.ModelUrls.csproj" />
+	</ItemGroup>
 </Project>

--- a/src/SchoStack.AspNetCore.Tests/MSTestSettings.cs
+++ b/src/SchoStack.AspNetCore.Tests/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/src/SchoStack.AspNetCore.Tests/ModelUrls/DefaultPropertyNameModifierTests.cs
+++ b/src/SchoStack.AspNetCore.Tests/ModelUrls/DefaultPropertyNameModifierTests.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SchoStack.AspNetCore.ModelUrls;
+
+namespace SchoStack.AspNetCore.Tests.ModelUrls
+{
+    [TestClass]
+    public class DefaultPropertyNameModifierTests
+    {
+        private class TestModel
+        {
+            public string NoAttribute { get; set; }
+
+            [FromQuery(Name = "customName")]
+            public string WithFromQuery { get; set; }
+        }
+
+        [TestMethod]
+        public void ReturnsPropertyName_WhenNoFromQueryAttribute()
+        {
+            var property = typeof(TestModel).GetProperty(nameof(TestModel.NoAttribute));
+            var attributes = Attribute.GetCustomAttributes(property);
+            var modifier = new DefaultPropertyNameModfier();
+
+            var result = modifier.GetModifiedPropertyName(property, attributes);
+
+            Assert.AreEqual("NoAttribute", result);
+        }
+
+        [TestMethod]
+        public void ReturnsFromQueryName_WhenFromQueryAttributePresent()
+        {
+            var property = typeof(TestModel).GetProperty(nameof(TestModel.WithFromQuery));
+            var attributes = Attribute.GetCustomAttributes(property);
+            var modifier = new DefaultPropertyNameModfier();
+
+            var result = modifier.GetModifiedPropertyName(property, attributes);
+
+            Assert.AreEqual("customName", result);
+        }
+    }
+}

--- a/src/SchoStack.AspNetCore.Tests/ModelUrls/RouteValueDictionaryGeneratorTests.cs
+++ b/src/SchoStack.AspNetCore.Tests/ModelUrls/RouteValueDictionaryGeneratorTests.cs
@@ -1,0 +1,269 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using NSubstitute;
+using SchoStack.AspNetCore.ModelUrls;
+using System.Reflection;
+
+namespace SchoStack.AspNetCore.Tests.ModelUrls
+{
+    [TestClass]
+    public class RouteValueDictionaryGeneratorTests
+    {
+        private class TestModel
+        {
+            public int IntValue { get; set; }
+            public double DoubleValue { get; set; }
+            public DateTime DateValue { get; set; }
+            public string StringValue { get; set; }
+            public Guid GuidValue { get; set; }
+            public CustomFormattable Formattable { get; set; }
+            public string SomeProperty { get; set; }
+            public NestedModel Nested { get; set; }
+            public List<NestedModel> Items { get; set; }
+        }
+
+        private class CustomFormattable : IFormattable
+        {
+            public int A { get; set; }
+            public int B { get; set; }
+            public string ToString(string format, IFormatProvider formatProvider) => $"A={A},B={B}";
+            public override string ToString() => ToString(null, null);
+        }
+
+        private class NestedModel
+        {
+            public string NestedValue { get; set; }
+            public int NestedInt { get; set; }
+            public NestedModel Deeper { get; set; }
+        }
+
+        private RouteValueDictionary GenerateRouteValues(object model, ActionConventionOptions options = null, string prefix = "", RouteValueDictionary dict = null)
+        {
+            var actionContext = new ActionContext();
+            options ??= new ActionConventionOptions();
+            var generator = new RouteValueDictionaryGenerator(actionContext, options);
+            return generator.Generate(model, prefix, dict);
+        }
+
+        [TestMethod]
+        public void ConvertibleTypes_Are_Added_Without_Expansion_Or_Conversion()
+        {
+            var now = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var model = new TestModel
+            {
+                IntValue = 42,
+                DoubleValue = 3.14,
+                DateValue = now,
+                StringValue = "hello"
+            };
+
+            var dict = GenerateRouteValues(model);
+
+            Assert.AreEqual(42, dict["IntValue"]);
+            Assert.AreEqual(3.14, dict["DoubleValue"]);
+            Assert.AreEqual(now, dict["DateValue"]);
+            Assert.AreEqual("hello", dict["StringValue"]);
+            Assert.IsFalse(dict.ContainsKey("DateValue.Day"));
+            Assert.IsFalse(dict.ContainsKey("StringValue.Length"));
+        }
+
+        [TestMethod]
+        public void IFormattable_Is_Added_Without_Expansion()
+        {
+            var model = new TestModel
+            {
+                Formattable = new CustomFormattable { A = 1, B = 2 }
+            };
+
+            var dict = GenerateRouteValues(model);
+
+            Assert.IsInstanceOfType(dict["Formattable"], typeof(CustomFormattable));
+            Assert.IsFalse(dict.ContainsKey("Formattable.A"));
+            Assert.IsFalse(dict.ContainsKey("Formattable.B"));
+            Assert.AreEqual(1, dict.Count);
+        }
+
+        [TestMethod]
+        public void TypeFormatter_Is_Used_And_Value_Is_Converted()
+        {
+            var guid = Guid.NewGuid();
+            var model = new TestModel { GuidValue = guid };
+            var options = new ActionConventionOptions();
+            options.AddTypeFormatter<Guid>((value, ctx) => ((Guid)value).ToString("N"));
+
+            var dict = GenerateRouteValues(model, options);
+
+            Assert.AreEqual(guid.ToString("N"), dict["GuidValue"]);
+        }
+
+        [TestMethod]
+        public void TypeFormatter_Takes_Precedence_Over_Convertible()
+        {
+            var model = new TestModel { IntValue = 123 };
+            var options = new ActionConventionOptions();
+            options.AddTypeFormatter<int>((value, ctx) => $"formatted-{value}");
+
+            var dict = GenerateRouteValues(model, options);
+
+            Assert.AreEqual("formatted-123", dict["IntValue"]);
+            Assert.AreEqual(1, dict.Count);
+        }
+
+        [TestMethod]
+        public void TypeFormatter_Takes_Precedence_Over_IFormattable()
+        {
+            var model = new TestModel
+            {
+                Formattable = new CustomFormattable { A = 5, B = 6 }
+            };
+            var options = new ActionConventionOptions();
+            options.AddTypeFormatter<CustomFormattable>((value, ctx) => "formatter-wins");
+
+            var dict = GenerateRouteValues(model, options);
+
+            Assert.AreEqual("formatter-wins", dict["Formattable"]);
+            Assert.IsFalse(dict.ContainsKey("Formattable.A"));
+            Assert.IsFalse(dict.ContainsKey("Formattable.B"));
+            Assert.AreEqual(1, dict.Count);
+        }
+
+        [TestMethod]
+        public void ComplexType_NotConvertible_ExpandsProperties()
+        {
+            var model = new { X = 1, Y = "abc" };
+            var dict = GenerateRouteValues(model);
+
+            Assert.AreEqual(1, dict["X"]);
+            Assert.AreEqual("abc", dict["Y"]);
+        }
+
+        [TestMethod]
+        public void Recursion_Expands_Nested_Complex_Properties()
+        {
+            var model = new TestModel
+            {
+                StringValue = "parent",
+                Nested = new NestedModel { NestedValue = "child", NestedInt = 99 }
+            };
+
+            var dict = GenerateRouteValues(model);
+
+            Assert.AreEqual("parent", dict["StringValue"]);
+            Assert.AreEqual("child", dict["Nested.NestedValue"]);
+            Assert.AreEqual(99, dict["Nested.NestedInt"]);
+        }
+
+        [TestMethod]
+        public void Recursion_Expands_Enumerable_Of_Complex_Properties()
+        {
+            var model = new TestModel
+            {
+                Items = new List<NestedModel>
+                {
+                    new NestedModel { NestedValue = "a", NestedInt = 1 },
+                    new NestedModel { NestedValue = "b", NestedInt = 2 }
+                }
+            };
+
+            var dict = GenerateRouteValues(model);
+
+            Assert.AreEqual("a", dict["Items[0].NestedValue"]);
+            Assert.AreEqual(1, dict["Items[0].NestedInt"]);
+            Assert.AreEqual("b", dict["Items[1].NestedValue"]);
+            Assert.AreEqual(2, dict["Items[1].NestedInt"]);
+        }
+
+        [TestMethod]
+        public void Recursion_Expands_Deeply_Nested_Properties()
+        {
+            var model = new TestModel
+            {
+                Nested = new NestedModel
+                {
+                    NestedValue = "level1",
+                    Deeper = new NestedModel
+                    {
+                        NestedValue = "level2",
+                        Deeper = new NestedModel
+                        {
+                            NestedValue = "deep"
+                        }
+                    }
+                }
+            };
+
+            var dict = GenerateRouteValues(model);
+
+            Assert.AreEqual("level1", dict["Nested.NestedValue"]);
+            Assert.AreEqual("level2", dict["Nested.Deeper.NestedValue"]);
+            Assert.AreEqual("deep", dict["Nested.Deeper.Deeper.NestedValue"]);
+        }
+
+        [TestMethod]
+        public void PropertyNameModifier_Is_Called_And_Output_Used()
+        {
+            var modifier = Substitute.For<DefaultPropertyNameModfier>();
+            var model = new TestModel { SomeProperty = "value" };
+            var options = new ActionConventionOptions { PropertyNameModifier = modifier };
+            modifier.GetModifiedPropertyName(Arg.Any<PropertyInfo>(), Arg.Any<Attribute[]>()).Returns("custom_key");
+
+            var dict = GenerateRouteValues(model, options);
+
+            modifier.Received().GetModifiedPropertyName(
+                Arg.Is<PropertyInfo>(pi => pi.Name == "SomeProperty"),
+                Arg.Any<Attribute[]>()
+            );
+            Assert.IsTrue(dict.ContainsKey("custom_key"));
+            Assert.AreEqual("value", dict["custom_key"]);
+        }
+
+        [TestMethod]
+        public void Prefix_Is_Only_Applied_To_Top_Level()
+        {
+            var model = new TestModel
+            {
+                IntValue = 1,
+                Nested = new NestedModel
+                {
+                    NestedValue = "inner",
+                    NestedInt = 2,
+                    Deeper = new NestedModel
+                    {
+                        NestedValue = "deep"
+                    }
+                }
+            };
+
+            var dict = GenerateRouteValues(model, prefix: "top.");
+
+            Assert.AreEqual(1, dict["top.IntValue"]);
+            Assert.AreEqual("inner", dict["top.Nested.NestedValue"]);
+            Assert.AreEqual(2, dict["top.Nested.NestedInt"]);
+            Assert.AreEqual("deep", dict["top.Nested.Deeper.NestedValue"]);
+            Assert.IsFalse(dict.ContainsKey("top.top.Nested.NestedValue"));
+            Assert.IsFalse(dict.ContainsKey("top.Nested.top.NestedValue"));
+        }
+
+        [TestMethod]
+        public void Existing_Dictionary_Is_Used()
+        {
+            var model = new TestModel
+            {
+                IntValue = 5,
+                StringValue = "abc"
+            };
+
+            var existing = new RouteValueDictionary
+            {
+                { "existing", 123 }
+            };
+
+            var dict = GenerateRouteValues(model, dict: existing);
+
+            Assert.AreSame(existing, dict);
+            Assert.AreEqual(123, dict["existing"]);
+            Assert.AreEqual(5, dict["IntValue"]);
+            Assert.AreEqual("abc", dict["StringValue"]);
+        }
+    }
+}

--- a/src/SchoStack.AspNetCore.Tests/SchoStack.AspNetCore.Tests.csproj
+++ b/src/SchoStack.AspNetCore.Tests/SchoStack.AspNetCore.Tests.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="MSTest.Sdk/3.6.4">
+	<Import Project="..\Common.props" />
+	<PropertyGroup>
+		<LangVersion>latest</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+	<ItemGroup>
+	  <PackageReference Include="NSubstitute" Version="5.3.0" />
+	</ItemGroup>
+	<ItemGroup>
+	  <ProjectReference Include="..\SchoStack.AspNetCore.FluentValidation\SchoStack.AspNetCore.FluentValidation.csproj" />
+	  <ProjectReference Include="..\SchoStack.AspNetCore.HtmlConventions\SchoStack.AspNetCore.HtmlConventions.csproj" />
+	  <ProjectReference Include="..\SchoStack.AspNetCore.Invoker\SchoStack.AspNetCore.Invoker.csproj" />
+	  <ProjectReference Include="..\SchoStack.AspNetCore.MediatR\SchoStack.AspNetCore.MediatR.csproj" />
+	  <ProjectReference Include="..\SchoStack.AspNetCore.ModelUrls\SchoStack.AspNetCore.ModelUrls.csproj" />
+	</ItemGroup>
+</Project>

--- a/src/SchoStack.AspNetCore.sln
+++ b/src/SchoStack.AspNetCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36109.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SchoStack.AspNetCore.ModelUrls", "SchoStack.AspNetCore.ModelUrls\SchoStack.AspNetCore.ModelUrls.csproj", "{41825DC8-50BA-49BB-B6FD-3630F24579A7}"
 EndProject
@@ -14,6 +14,13 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SchoStack.AspNetCore.Invoker", "SchoStack.AspNetCore.Invoker\SchoStack.AspNetCore.Invoker.csproj", "{7EC91209-7C39-4FE1-A780-0103B74E7E60}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SchoStack.AspNetCore.MediatR", "SchoStack.AspNetCore.MediatR\SchoStack.AspNetCore.MediatR.csproj", "{08BA5637-9BBD-48CF-B89C-3F5905C5F491}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
+	ProjectSection(SolutionItems) = preProject
+		Common.props = Common.props
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SchoStack.AspNetCore.Tests", "SchoStack.AspNetCore.Tests\SchoStack.AspNetCore.Tests.csproj", "{6A74F7D1-3D63-4238-B5DD-9DCA2F0F4089}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +52,10 @@ Global
 		{08BA5637-9BBD-48CF-B89C-3F5905C5F491}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08BA5637-9BBD-48CF-B89C-3F5905C5F491}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08BA5637-9BBD-48CF-B89C-3F5905C5F491}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A74F7D1-3D63-4238-B5DD-9DCA2F0F4089}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A74F7D1-3D63-4238-B5DD-9DCA2F0F4089}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A74F7D1-3D63-4238-B5DD-9DCA2F0F4089}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A74F7D1-3D63-4238-B5DD-9DCA2F0F4089}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Update target frameworks to .NET6 and .NET8. Allow type formatter to be used in route value dictionary generation for converting any type to a string and treat IFormattable types as simple conversions.

+ Version bumps due to .NET8 support
+ ModelUrls version bumped to 1.1.0 due to functionality change
+ Some tests